### PR TITLE
Improve the English text of the popup message

### DIFF
--- a/library/res/values/strings.xml
+++ b/library/res/values/strings.xml
@@ -1,9 +1,9 @@
 <resources>
 
     <string name="rta_dialog_title">Rate this app</string>
-    <string name="rta_dialog_message">If you enjoy this app, please take a moment to rate this app. It won\'t take more than a minute. Thank you for your support!</string>
+    <string name="rta_dialog_message">If you enjoy using this app, would you mind taking a moment to rate it? It won\'t take more than a minute. Thank you for your support!</string>
     <string name="rta_dialog_ok">Rate now</string>
-    <string name="rta_dialog_cancel">Remind later</string>
+    <string name="rta_dialog_cancel">Later</string>
     <string name="rta_dialog_no">No, thanks</string>
 
 </resources>


### PR DESCRIPTION
Changes:
1. Ask to rate, instead of command.
2. Don't repeat "the app", it's redundant. That's what "it" is for.
3. Change "Remind later" which sounds broken to "Later", which is an acceptable short form to "Remind me later", especially given the implied "I don't have time to rate it now, stop bothering me!!!".