### PR TITLE
Keep instance variables and prefs in sync.

### DIFF
--- a/ratethisapp/src/main/java/com/kobakei/ratethisapp/RateThisApp.java
+++ b/ratethisapp/src/main/java/com/kobakei/ratethisapp/RateThisApp.java
@@ -312,6 +312,8 @@ public class RateThisApp {
         editor.remove(KEY_INSTALL_DATE);
         editor.remove(KEY_LAUNCH_TIMES);
         editor.apply();
+        mLaunchTimes = 0;
+        mInstallDate.setTime(0);
     }
 
     /**
@@ -355,10 +357,12 @@ public class RateThisApp {
      * @param context
      */
     private static void storeAskLaterDate(final Context context) {
+        long currentTime = System.currentTimeMillis();
         SharedPreferences pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
         Editor editor = pref.edit();
-        editor.putLong(KEY_ASK_LATER_DATE, System.currentTimeMillis());
+        editor.putLong(KEY_ASK_LATER_DATE, currentTime);
         editor.apply();
+        mAskLaterDate.setTime(currentTime);
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where:

1. dialog is shown;
2. user presses "neutral" button;
3. immediately call `shouldShowRateDialog` and get `true`.

This affects me because I'm not showing the dialog in `onCreate` (which is when preferences are loaded). I call `showRateDialogIfNeeded` during the lifetime of my activity, and if the user presses "neutral" the dialog might be show again and again until the activity is recreated and preferences reloaded.